### PR TITLE
feat(#2): RAG 파이프라인 구축

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,69 @@
+"""RAG 문서 임베딩 및 FAISS 벡터DB 구축"""
+import os
+from langchain_community.document_loaders import TextLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_community.vectorstores import FAISS
+from config import (
+    DATA_DIR, RAG_FILES, EMBEDDING_MODEL,
+    CHUNK_SIZE, CHUNK_OVERLAP, VECTORSTORE_PATH,
+)
+
+
+def load_documents():
+    """RAG 대상 문서 5개 로드"""
+    docs = []
+    for fname in RAG_FILES:
+        path = os.path.join(DATA_DIR, fname)
+        loader = TextLoader(path, encoding="utf-8")
+        loaded = loader.load()
+        for doc in loaded:
+            doc.metadata["source"] = fname
+        docs.extend(loaded)
+    print(f"[ingest] {len(docs)}개 문서 로드 완료")
+    return docs
+
+
+def split_documents(docs):
+    """문서 청킹 (1,000자 / 오버랩 200자)"""
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=CHUNK_SIZE,
+        chunk_overlap=CHUNK_OVERLAP,
+        separators=["\n## ", "\n### ", "\n\n", "\n", " "],
+    )
+    chunks = splitter.split_documents(docs)
+    print(f"[ingest] {len(chunks)}개 청크 생성 완료")
+    return chunks
+
+
+def create_vectorstore(chunks):
+    """FAISS 벡터DB 생성 및 저장"""
+    embeddings = HuggingFaceEmbeddings(
+        model_name=EMBEDDING_MODEL,
+        model_kwargs={"device": "cpu"},
+        encode_kwargs={"normalize_embeddings": True},
+    )
+    vectorstore = FAISS.from_documents(chunks, embeddings)
+    vectorstore.save_local(VECTORSTORE_PATH)
+    print(f"[ingest] 벡터DB 저장 완료: {VECTORSTORE_PATH}")
+    return vectorstore
+
+
+def load_vectorstore():
+    """저장된 FAISS 벡터DB 로드"""
+    embeddings = HuggingFaceEmbeddings(
+        model_name=EMBEDDING_MODEL,
+        model_kwargs={"device": "cpu"},
+        encode_kwargs={"normalize_embeddings": True},
+    )
+    vectorstore = FAISS.load_local(
+        VECTORSTORE_PATH, embeddings, allow_dangerous_deserialization=True
+    )
+    print(f"[ingest] 벡터DB 로드 완료")
+    return vectorstore
+
+
+if __name__ == "__main__":
+    docs = load_documents()
+    chunks = split_documents(docs)
+    create_vectorstore(chunks)

--- a/tools/rag_tool.py
+++ b/tools/rag_tool.py
@@ -1,0 +1,70 @@
+"""Agentic RAG 검색 도구"""
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from ingest import load_vectorstore
+from config import LLM_MODEL, LLM_TEMPERATURE, TOP_K
+
+vectorstore = None
+
+
+def get_vectorstore():
+    """벡터DB 싱글턴 로드"""
+    global vectorstore
+    if vectorstore is None:
+        vectorstore = load_vectorstore()
+    return vectorstore
+
+
+def query_rewrite(query: str) -> str:
+    """질의를 검색에 최적화된 형태로 재작성"""
+    llm = ChatOpenAI(model=LLM_MODEL, temperature=0)
+    prompt = ChatPromptTemplate.from_template(
+        "다음 질문을 벡터 검색에 최적화된 키워드 중심 질의로 재작성하세요.\n"
+        "원래 질문: {query}\n"
+        "재작성된 질의:"
+    )
+    chain = prompt | llm | StrOutputParser()
+    return chain.invoke({"query": query})
+
+
+def check_relevance(query: str, context: str) -> bool:
+    """검색 결과가 질의에 충분히 답할 수 있는지 판단"""
+    llm = ChatOpenAI(model=LLM_MODEL, temperature=0)
+    prompt = ChatPromptTemplate.from_template(
+        "다음 질문에 대해 주어진 문맥이 충분한 정보를 제공하는지 판단하세요.\n\n"
+        "질문: {query}\n\n"
+        "문맥:\n{context}\n\n"
+        "'충분' 또는 '부족'으로만 답하세요:"
+    )
+    chain = prompt | llm | StrOutputParser()
+    result = chain.invoke({"query": query, "context": context})
+    return "충분" in result
+
+
+def rag_search(query: str) -> dict:
+    """
+    Agentic RAG 검색 실행
+
+    Returns:
+        {"context": str, "sources": list, "needs_web": bool}
+    """
+    # 1. Query Rewriting
+    rewritten = query_rewrite(query)
+
+    # 2. Vector Search
+    vs = get_vectorstore()
+    results = vs.similarity_search(rewritten, k=TOP_K)
+
+    context = "\n\n".join([doc.page_content for doc in results])
+    sources = list(set([doc.metadata.get("source", "") for doc in results]))
+
+    # 3. Relevance Check
+    is_relevant = check_relevance(query, context)
+
+    return {
+        "context": context,
+        "sources": sources,
+        "needs_web": not is_relevant,
+        "rewritten_query": rewritten,
+    }


### PR DESCRIPTION
## Summary
- ingest.py: 문서 로드 → 청킹(1000자/200자 오버랩) → FAISS 벡터DB
- tools/rag_tool.py: Query Rewriting + 관련성 판단 + Agentic RAG 검색

Closes #2